### PR TITLE
Proposal: Add debugger configuration for VS Code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,4 +70,5 @@ capybara-*.html
 .rspec
 
 # Ignore editor configs
-/.vscode
+/.vscode/*
+!/.vscode/launch.json

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,39 @@
+{
+	"version": "0.2.0",
+	"configurations": [
+		{
+			"name": "RSpec - all",
+			"type": "Ruby",
+			"request": "launch",
+			"program": "${workspaceRoot}/bin/bundle",
+			"args": [
+				"exec", "rspec",
+				"-I",
+				"${workspaceRoot}"
+			]
+		},
+		{
+			"name": "RSpec - active spec file only",
+			"type": "Ruby",
+			"request": "launch",
+			"program": "${workspaceRoot}/bin/bundle",
+			"args": [
+				"exec", "rspec",
+				"-I",
+				"${workspaceRoot}",
+				"${file}"
+			],
+			"debuggerPort": "13000"
+		},
+		{
+			"name": "Rails server",
+			"type": "Ruby",
+			"request": "launch",
+			"program": "${workspaceRoot}/bin/rails",
+			"args": [
+				"server"
+			],
+			"debuggerPort": "13000"
+		}
+	]
+}


### PR DESCRIPTION
I am aware of the convention that editor files are usually added to the `.gitignore`, but in this particular case, I cannot imagine how you should want to configure VS Code else, so I am proposing this patch in order to facilitate all other VS Coders to use the debugger for RoR. What do you think? IMO, this is not more tool-specific than the new Vagrantfile (#41). :-)