### PR TITLE
Make alerts dismissable, make alerts floating on dashboard

### DIFF
--- a/app/assets/stylesheets/home.scss
+++ b/app/assets/stylesheets/home.scss
@@ -6,6 +6,13 @@ html, body {
   height: 100%;
 }
 
+.alert {
+  position: fixed;
+  z-index: 1;
+  left: 50%;
+  transform: translateX(-50%);
+}
+
 #app {
   padding: 0;
   display: flex;

--- a/app/views/layouts/desktop.html.erb
+++ b/app/views/layouts/desktop.html.erb
@@ -11,8 +11,22 @@
   <div id="app">
     <%= render "layouts/navbar" %>
     <div id="content" class="container pt-3">
-      <% if notice %><div class="alert alert-success notice" role="alert"><%= notice %></div><% end %>
-      <% if alert %><div class="alert alert-danger" role="alert"><%= alert %></div><% end %>
+      <% if notice %>
+        <div class="alert alert-success alert-dismissible fade show notice" role="alert">
+          <%= notice %>
+          <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+            <span aria-hidden="true">&times;</span>
+          </button>
+        </div>
+      <% end %>
+      <% if alert %>
+        <div class="alert alert-danger alert-dismissible fade show" role="alert">
+          <%= alert %>
+          <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+            <span aria-hidden="true">&times;</span>
+          </button>
+        </div>
+      <% end %>
       <%= yield %>
     </div>
   </div>


### PR DESCRIPTION
This PR makes alerts look like the following on the dashboard. They can be dismissed easily and no longer mess up the sites structure.

![image](https://user-images.githubusercontent.com/22522058/104188594-be62e580-5419-11eb-95cf-5dc68784fe93.png)

On sites other than the dashboard, e.g. when logging out, it looks like the following.

![image](https://user-images.githubusercontent.com/22522058/104188696-efdbb100-5419-11eb-9340-cc9497b9e26d.png)
