### PR TITLE
Fix social account links

### DIFF
--- a/app/helpers/social_accounts_helper.rb
+++ b/app/helpers/social_accounts_helper.rb
@@ -4,9 +4,9 @@ module SocialAccountsHelper
     'Telegram' => ->(name) { "https://t.me/#{name}" },
     'Facebook' => ->(name) { "https://facebook.com/#{name}" },
     'Twitter' => ->(name) { "https://twitter.com/#{name}" },
-    'GitLab@HPI' => ->(name) { "https://gitlab.hpi.de.com/#{name}" },
-    'Slack' => proc { 'https://slack.com/' },
-    'Discord' => ->(name) { "https://discordapp.com/#{name}" }
+    'GitLab@HPI' => ->(name) { "https://gitlab.hpi.de/#{name}" },
+    'Slack' => proc { "https://slack.com/" },
+    'Discord' => proc { "https://discordapp.com/" }
   }.freeze
 
   def generate_link(social_account)

--- a/app/helpers/social_accounts_helper.rb
+++ b/app/helpers/social_accounts_helper.rb
@@ -5,8 +5,8 @@ module SocialAccountsHelper
     'Facebook' => ->(name) { "https://facebook.com/#{name}" },
     'Twitter' => ->(name) { "https://twitter.com/#{name}" },
     'GitLab@HPI' => ->(name) { "https://gitlab.hpi.de/#{name}" },
-    'Slack' => proc { "https://slack.com/" },
-    'Discord' => proc { "https://discordapp.com/" }
+    'Slack' => proc { 'https://slack.com/' },
+    'Discord' => proc { 'https://discordapp.com/' }
   }.freeze
 
   def generate_link(social_account)


### PR DESCRIPTION
- Fix HPI-Gitlab link, since it was broken
- I don't think there are direct links to Discord user accounts, so that option was removed