### PR TITLE
Add handling of a log of type string

### DIFF
--- a/app/views/layouts/_flash_messages.html.erb
+++ b/app/views/layouts/_flash_messages.html.erb
@@ -1,12 +1,17 @@
 <% flash.each do |level, log| %>
     <div class='alert alert-<%= level %>'>
-      <% if !log[:heading].nil? %>
-        <h4><%= log[:heading] %></h4>
+      <% if log.is_a? String %>
+        <li><%= log %></li>
       <% end %>
-      <% log[:messages].each do |message| %>
-        <ul>
-          <li><%= message %></li>
-        </ul>
+      <% if !log.is_a? String %>
+        <% if !log[:heading].nil? %>
+          <h4><%= log[:heading] %></h4>
+        <% end %>
+        <% log[:messages].each do |message| %>
+          <ul>
+            <li><%= message %></li>
+          </ul>
+        <% end %>
       <% end %>
     </div>
 <% end %>


### PR DESCRIPTION
There is an issue with the flash messages when logging out. The partial can only handle a dictionary with a heading and message. Somehow we are receiving a string instead of a dictionary while logging out. To fix this issue we simply check the type now. Not the best solution but for now it should work.