### PR TITLE
Rework flaky tests in user search spec

### DIFF
--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -28,7 +28,7 @@ FactoryBot.define do
       firstname { 'Erika' }
       lastname { 'Musterfrau' }
       username { 'erika.musterfrau' }
-      email { 'erika.musterfrau@example.com' }
+      email { 'test2@example.com' }
     end
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -16,6 +16,20 @@ FactoryBot.define do
         user.init
       end
     end
+
+    trait :maximilian do
+      firstname { 'Maximilian' }
+      lastname { 'Mustermann' }
+      username { 'standard_user' }
+      email { 'test@example.com' }
+    end
+
+    trait :erika do
+      firstname { 'Erika' }
+      lastname { 'Musterfrau' }
+      username { 'erika.musterfrau' }
+      email { 'erika.musterfrau@example.com' }
+    end
   end
 end
 

--- a/spec/features/user_edit_profile_spec.rb
+++ b/spec/features/user_edit_profile_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe 'Users profile page', driver: :selenium_headless, type: :feature 
       (I18n.t 'social_accounts.social_account_view.remove_label'),
       href: user_social_account_path(user, social_account1.id)
     ).click
-    expect(page).not_to have_content(social_account1.user_name)
+    expect(page).not_to have_text(social_account1.user_name)
   end
 
   it 'provides link to social account website' do

--- a/spec/features/user_search_spec.rb
+++ b/spec/features/user_search_spec.rb
@@ -2,50 +2,75 @@ require 'rails_helper'
 
 describe 'Filter users by key', type: :feature do
   let(:user) { FactoryBot.create :user }
-  let(:second_user) { FactoryBot.create :user }
 
-  before do
-    second_user
-    sign_in user
+  before { sign_in user }
+
+  describe 'without filter' do
+    let!(:users) { FactoryBot.create_list(:user, 3) }
+
+    before { visit search_users_path }
+
+    it 'does show all other users when no filter is given' do
+      users.each { |user| expect(page).to have_text(user.email) }
+    end
+
+    it 'does not show myself' do
+      expect(page).not_to have_text(user.email)
+    end
   end
 
-  it 'is possible to filter by firstname' do
-    visit search_users_path(search: second_user.firstname[0..2])
-    expect(page).to have_text(second_user.firstname)
-  end
+  describe 'with filter' do
+    let!(:erika) { FactoryBot.create :user, :erika }
+    let!(:maximilian) { FactoryBot.create :user, :maximilian }
 
-  it 'is possible to filter by lastname' do
-    visit search_users_path(search: second_user.lastname[0..2])
-    expect(page).to have_text(second_user.lastname)
-  end
+    before { visit search_users_path(search: search) }
 
-  it 'is possible to filter by username' do
-    visit search_users_path(search: second_user.username[0..2])
-    expect(page).to have_text(second_user.username)
-  end
+    context 'with part of firstname' do
+      let(:search) { 'aximi' }
 
-  it 'is possible to filter by email' do
-    visit search_users_path(search: second_user.email[0..2])
-    expect(page).to have_text(second_user.email)
-  end
+      it 'is possible to filter by firstname' do
+        expect(page).to have_text(maximilian.email)
+      end
 
-  it 'does not show non-matching users when filtering by firstname' do
-    visit search_users_path(search: user.firstname[0..2])
-    expect(page).not_to have_text(second_user.firstname)
-  end
+      it 'does not show non-matching users when filtering by firstname' do
+        expect(page).not_to have_text(erika.email)
+      end
+    end
 
-  it 'does not show non-matching users when filtering by lastname' do
-    visit search_users_path(search: user.lastname[0..2])
-    expect(page).not_to have_text(second_user.lastname)
-  end
+    context 'with part of lastname' do
+      let(:search) { 'erma' }
 
-  it 'does not show non-matching users when filtering by username' do
-    visit search_users_path(search: user.username[0..2])
-    expect(page).not_to have_text(second_user.username)
-  end
+      it 'is possible to filter by lastname' do
+        expect(page).to have_text(maximilian.email)
+      end
 
-  it 'does not show non-matching users when filtering by email' do
-    visit search_users_path(search: user.email[0..2])
-    expect(page).not_to have_text(second_user.email)
+      it 'does not show non-matching users when filtering by lastname' do
+        expect(page).not_to have_text(erika.email)
+      end
+    end
+
+    context 'with part of username' do
+      let(:search) { 'andard_' }
+
+      it 'is possible to filter by username' do
+        expect(page).to have_text(maximilian.email)
+      end
+
+      it 'does not show non-matching users when filtering by username' do
+        expect(page).not_to have_text(erika.email)
+      end
+    end
+
+    context 'with part of email' do
+      let(:search) { 'test@exa' }
+
+      it 'is possible to filter by email' do
+        expect(page).to have_text(maximilian.email)
+      end
+
+      it 'does not show non-matching users when filtering by email' do
+        expect(page).not_to have_text(erika.email)
+      end
+    end
   end
 end

--- a/spec/features/user_search_spec.rb
+++ b/spec/features/user_search_spec.rb
@@ -10,7 +10,7 @@ describe 'Filter users by key', type: :feature do
 
     before { visit search_users_path }
 
-    it 'does show all other users when no filter is given' do
+    it 'shows all other users when no filter is given' do
       users.each { |user| expect(page).to have_text(user.email) }
     end
 


### PR DESCRIPTION
This uses predefined users (via a FactoryBot trait) in the user search spec (`spec/features/user_search_spec.rb`) so that these specs do not fail some of the time due to bad luck with the random names of the default user factory.  
The problem was mentioned [here](https://github.com/hpi-swt2/connections-portal/pull/100#discussion_r559185070) and [here](https://github.com/hpi-swt2/connections-portal/pull/150#issuecomment-765705962).  

I now made sure that all strings that are searched for occur exactly in one user in the tested attribute.