### PR TITLE
Restore desktop navbar part

### DIFF
--- a/app/assets/stylesheets/home.scss
+++ b/app/assets/stylesheets/home.scss
@@ -31,6 +31,10 @@ html, body {
   flex-wrap: wrap;
 }
 
+.portal-link {
+  color: white;
+}
+
 #dashboard-row {
   height: 100%;
   width: 100%;

--- a/app/assets/stylesheets/home_mobile.scss
+++ b/app/assets/stylesheets/home_mobile.scss
@@ -28,3 +28,7 @@ html, body {
 .tab-content {
   width: 100%;
 }
+
+.navbar-desktop-part {
+  display: none;
+}

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -1,6 +1,6 @@
 <%# https://getbootstrap.com/docs/4.5/components/navbar/ %>
 <nav class="navbar navbar-expand-md navbar-dark bg-dark">
-  <div class="navbar-brand"><%= I18n.t('index.portal_name') %></div>
+  <div class="navbar-brand"><%= link_to I18n.t('index.portal_name'), root_path, class: 'portal-link' %></div>
   <form class="form-inline">
     <i class="fa fa-bell" style="color: white; padding: 10px"></i>
     <a href="<%= search_users_path %>"><i class="fa fa-search" style="color: white; padding: 10px"></i> </a>

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -5,4 +5,5 @@
     <i class="fa fa-bell" style="color: white; padding: 10px"></i>
     <a href="<%= search_users_path %>"><i class="fa fa-search" style="color: white; padding: 10px"></i> </a>
   </form>
+<%= render 'layouts/navbar_desktop_part' %>
 </nav>

--- a/app/views/layouts/_navbar_desktop_part.html.erb
+++ b/app/views/layouts/_navbar_desktop_part.html.erb
@@ -1,0 +1,20 @@
+<%# Loaded only on desktop, directly into the navbar %>
+<ul class="navbar-nav ml-auto navbar-desktop-part">
+  <%# https://github.com/heartcombo/devise#controller-filters-and-helpers %>
+  <% if user_signed_in? %>
+    <li class="nav-item dropdown">
+      <a class="nav-link dropdown-toggle" href id="navbarProfileDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+        <%= current_user.display_name %>
+      </a>
+      <div class="dropdown-menu" aria-labelledby="navbarProfileDropdown">
+        <%= link_to I18n.t('navigation.visit_profile'), user_path(current_user), class: 'dropdown-item' %>
+        <div class="dropdown-divider"></div>
+        <%= link_to I18n.t('navigation.edit_profile'), edit_user_path(current_user), class: 'dropdown-item' %>
+        <%= link_to I18n.t('navigation.account_settings'), edit_user_registration_path(current_user), class: 'dropdown-item' %>
+      </div>
+    </li>
+    <li class="nav-item">
+      <%= link_to (fa_icon 'sign-out', text: 'Log Out'), destroy_user_session_path, method: :delete, class: 'nav-link' %>
+    </li>
+  <% end %>
+</ul>

--- a/spec/features/dashboard/user_list_spec.rb
+++ b/spec/features/dashboard/user_list_spec.rb
@@ -16,7 +16,9 @@ RSpec.describe 'User list', type: :feature do
     end
 
     it 'does not show the current user' do
-      expect(page).not_to have_text(user.display_name)
+      within('#filtered_user_list') do
+        expect(page).not_to have_text(user.display_name)
+      end
     end
 
     it 'does not show users with another status' do

--- a/spec/features/navbar_desktop_spec.rb
+++ b/spec/features/navbar_desktop_spec.rb
@@ -1,0 +1,66 @@
+require 'rails_helper'
+
+RSpec.describe 'Navbar', driver: :selenium_headless, type: :feature, js: true do
+  let(:user) { FactoryBot.create :user }
+
+  describe 'profile dropdown' do
+    before do
+      sign_in user
+      visit root_path
+    end
+
+    it 'is not expanded by default' do
+      profile_dropdown = page.find('#navbarProfileDropdown + div', visible: :all)
+      expect(profile_dropdown['class']).not_to include('show')
+    end
+
+    it 'expands after being clicked on' do
+      toggle_profile_dropdown
+      profile_dropdown = page.find('#navbarProfileDropdown + div')
+      expect(profile_dropdown['class']).to include('show')
+    end
+
+    it 'contains a link to the users profile page' do
+      toggle_profile_dropdown
+      within '#navbarProfileDropdown + div' do
+        expect(page).to have_link(href: user_path(user))
+      end
+    end
+
+    it 'contains a link to the account settings page' do
+      toggle_profile_dropdown
+      within '#navbarProfileDropdown + div' do
+        expect(page).to have_link(href: edit_user_registration_path(user))
+      end
+    end
+
+    it 'contains a link to the users edit profile page' do
+      toggle_profile_dropdown
+      within '#navbarProfileDropdown + div' do
+        expect(page).to have_link(href: edit_user_path(user))
+      end
+    end
+
+    def toggle_profile_dropdown
+      page.execute_script('document.getElementById("navbarProfileDropdown").click()')
+    end
+  end
+
+  describe 'public page' do
+    before do
+      visit root_path
+    end
+
+    it 'does not contain a link to the notes page' do
+      expect(page).not_to have_link(href: notes_path)
+    end
+
+    it 'does not contain a link to the users page' do
+      expect(page).not_to have_link(href: users_path)
+    end
+
+    it 'does not contain a link to the contacts page' do
+      expect(page).not_to have_link('My contacts')
+    end
+  end
+end


### PR DESCRIPTION
With the new navbar geared towards mobile, functionality for the desktop was removed. This PR reintroduces the drop down menu and sign out button removed in #147, it is only shown on the Desktop.
Don't worry product owners, this was done in my spare time and did not remove any time spent focusing on the mobile layout. This was just something I'd like personally.