### PR TITLE
Add a link to the contact page in Desktop navbar

### DIFF
--- a/app/views/layouts/_navbar_desktop_part.html.erb
+++ b/app/views/layouts/_navbar_desktop_part.html.erb
@@ -9,6 +9,8 @@
       <div class="dropdown-menu" aria-labelledby="navbarProfileDropdown">
         <%= link_to I18n.t('navigation.visit_profile'), user_path(current_user), class: 'dropdown-item' %>
         <div class="dropdown-divider"></div>
+        <%= link_to I18n.t('navigation.contacts'), user_contacts_path(current_user), class: 'dropdown-item' %>
+        <div class="dropdown-divider"></div>
         <%= link_to I18n.t('navigation.edit_profile'), edit_user_path(current_user), class: 'dropdown-item' %>
         <%= link_to I18n.t('navigation.account_settings'), edit_user_registration_path(current_user), class: 'dropdown-item' %>
       </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -44,6 +44,7 @@ en:
   navigation:
     visit_profile: 'Visit my profile'
     edit_profile: 'Edit my profile'
+    contacts: 'View contacts'
     account_settings: 'Account settings'
     log_in: 'Log-In'
     sign_up: 'Sign-Up'

--- a/spec/features/navbar_desktop_spec.rb
+++ b/spec/features/navbar_desktop_spec.rb
@@ -27,6 +27,13 @@ RSpec.describe 'Navbar', driver: :selenium_headless, type: :feature, js: true do
       end
     end
 
+    it 'contains a link to contacts page' do
+      toggle_profile_dropdown
+      within '#navbarProfileDropdown + div' do
+        expect(page).to have_link(href: user_contacts_path(user))
+      end
+    end
+
     it 'contains a link to the account settings page' do
       toggle_profile_dropdown
       within '#navbarProfileDropdown + div' do


### PR DESCRIPTION
With this commit, all Desktop issues in #160 will be solved, since contact requests are accessible from the contacts page.