### PR TITLE
Prevent 500 error when viewing user without profile picture

### DIFF
--- a/app/views/users/_card.html.erb
+++ b/app/views/users/_card.html.erb
@@ -7,7 +7,7 @@
             <%= image_tag user.avatar, height: 65, width: 65, class: "rounded-circle" %>
           <% else %>
             <img class="rounded_circle" width="65" height="65" alt="profile-picture"
-              src="todo">
+              src="https://user-images.githubusercontent.com/48409110/107123576-8aef6b80-689e-11eb-9386-16eecd0ceb9e.png">
           <% end %>
         </div>
         <a class="col-8" href=<%= user_path(user) %>>

--- a/app/views/users/_card.html.erb
+++ b/app/views/users/_card.html.erb
@@ -3,7 +3,12 @@
     <div class="container">
       <div class="row">
         <div class="col-xs">
-          <%= image_tag user.avatar, height: 65, width: 65, class: "rounded-circle" %>
+          <% if user.avatar.attached? %>
+            <%= image_tag user.avatar, height: 65, width: 65, class: "rounded-circle" %>
+          <% else %>
+            <img class="rounded_circle" width="65" height="65" alt="profile-picture"
+              src="todo">
+          <% end %>
         </div>
         <a class="col-8" href=<%= user_path(user) %>>
           <h5 class="card-title"><%= user.display_name %></h5>


### PR DESCRIPTION
This only shows the user's avatar if the user has one attached. Otherwise it just shows the following picture:

![image](https://user-images.githubusercontent.com/48409110/107123576-8aef6b80-689e-11eb-9386-16eecd0ceb9e.png)

This fixes #191 
It **DOES NOT** fix the problem described in #182 
